### PR TITLE
Fix duplicate connection counting

### DIFF
--- a/belonging/model.py
+++ b/belonging/model.py
@@ -16,10 +16,21 @@ class Community:
         return cls(members=data.get('members', []), connections=connections)
 
     def belonging_score(self) -> float:
-        """Return a simple connection density score between 0 and 1."""
+        """Return a simple connection density score between 0 and 1.
+
+        Duplicate or reversed connections are ignored so the score never
+        exceeds 1.0.
+        """
         n = len(self.members)
         if n < 2:
             return 0.0
         max_connections = n * (n - 1) // 2
-        actual_connections = len(self.connections)
+
+        unique_connections = {
+            frozenset(pair)
+            for pair in self.connections
+            if len(pair) == 2 and pair[0] != pair[1]
+        }
+        actual_connections = len(unique_connections)
+
         return actual_connections / max_connections

--- a/data/nexus_sample_data_duplicates.json
+++ b/data/nexus_sample_data_duplicates.json
@@ -1,0 +1,11 @@
+{
+  "nodes": ["Alpha", "Beta", "Gamma", "Delta"],
+  "links": [
+    ["Alpha", "Beta"],
+    ["Beta", "Alpha"],
+    ["Alpha", "Gamma"],
+    ["Beta", "Gamma"],
+    ["Gamma", "Delta"],
+    ["Delta", "Gamma"]
+  ]
+}

--- a/data/sample_data_duplicates.json
+++ b/data/sample_data_duplicates.json
@@ -1,0 +1,11 @@
+{
+  "members": ["Alice", "Bob", "Charlie", "Dana"],
+  "connections": [
+    ["Alice", "Bob"],
+    ["Bob", "Alice"],
+    ["Alice", "Charlie"],
+    ["Bob", "Charlie"],
+    ["Charlie", "Dana"],
+    ["Charlie", "Dana"]
+  ]
+}

--- a/nexus_ai/model.py
+++ b/nexus_ai/model.py
@@ -16,10 +16,21 @@ class Network:
         return cls(nodes=data.get('nodes', []), links=links)
 
     def network_score(self) -> float:
-        """Return a simple link density score between 0 and 1."""
+        """Return a simple link density score between 0 and 1.
+
+        Duplicate or reversed links are ignored so the score never exceeds
+        1.0.
+        """
         n = len(self.nodes)
         if n < 2:
             return 0.0
         max_links = n * (n - 1) // 2
-        actual_links = len(self.links)
+
+        unique_links = {
+            frozenset(pair)
+            for pair in self.links
+            if len(pair) == 2 and pair[0] != pair[1]
+        }
+        actual_links = len(unique_links)
+
         return actual_links / max_links

--- a/tests/test_model_duplicates.py
+++ b/tests/test_model_duplicates.py
@@ -1,0 +1,5 @@
+from belonging.model import Community
+
+def test_belonging_score_dedup():
+    community = Community.from_json('data/sample_data_duplicates.json')
+    assert abs(community.belonging_score() - 0.67) < 0.01

--- a/tests/test_nexus_model_duplicates.py
+++ b/tests/test_nexus_model_duplicates.py
@@ -1,0 +1,5 @@
+from nexus_ai.model import Network
+
+def test_network_score_dedup():
+    network = Network.from_json('data/nexus_sample_data_duplicates.json')
+    assert abs(network.network_score() - 0.67) < 0.01


### PR DESCRIPTION
## Summary
- prevent duplicates from inflating `belonging_score`
- prevent duplicates from inflating `network_score`
- add tests with duplicate data

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685fbcb3f3e8832abd619d4c8536a208