### PR TITLE
Apply QA fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Use the CLI to compute a belonging score:
 ```bash
 python -m belonging.cli data/sample_data.json
 ```
-
 Example output:
 ```
 $ python -m belonging.cli data/sample_data.json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,4 +9,8 @@ def test_cli_output():
         text=True,
         check=True,
     )
-    assert 'Belonging score:' in result.stdout
+    expected = (
+        "Members: Alice, Bob, Charlie, Dana\n"
+        "Belonging score: 0.67\n"
+    )
+    assert result.stdout == expected

--- a/tests/test_nexus_cli.py
+++ b/tests/test_nexus_cli.py
@@ -9,4 +9,8 @@ def test_cli_output():
         text=True,
         check=True,
     )
-    assert 'Network score:' in result.stdout
+    expected = (
+        "Nodes: Alpha, Beta, Gamma, Delta\n"
+        "Network score: 0.67\n"
+    )
+    assert result.stdout == expected


### PR DESCRIPTION
## Summary
- fix README formatting to keep example output tight to code block
- verify full text of CLI output in tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fbcb3b36c832a8e06eb089e8432c3